### PR TITLE
FIX as per SPOJ endpoint changes

### DIFF
--- a/spojbackup.py
+++ b/spojbackup.py
@@ -75,7 +75,7 @@ def getSolutions (path_prefix, path_proxy):
 
     # authenticate the user
     print "Authenticating " + username
-    br.open ("http://spoj.com/login")
+    br.open ("https://spoj.com/login")
     #br.select_form (name="login")
     #the form no longer is named "login" therefore to access it by id:
     formcount=0
@@ -91,7 +91,7 @@ def getSolutions (path_prefix, path_proxy):
     # sign in for a day to avoid timeouts
     #br.find_control(name="autologin").items[0].selected = True
     #this attribute is missing in the new spoj format
-    br.form.action = "http://www.spoj.com/login"
+    br.form.action = "https://www.spoj.com/login"
     response = br.submit()
 
     verify = response.read()
@@ -101,7 +101,7 @@ def getSolutions (path_prefix, path_proxy):
 
     # grab the signed submissions list
     print "Grabbing siglist for " + username
-    siglist = br.open("http://www.spoj.pl/status/" + username + "/signedlist")
+    siglist = br.open("https://www.spoj.com/status/" + username + "/signedlist")
 
     # dump first nine useless lines in signed list for formatting
     for i in xrange(9):
@@ -145,7 +145,7 @@ def downloadSolutions(mysublist):
         if len(existing_files) == 1:
             print "%d/%d - %s skipped." % (progress, totalsubmissions, entry[3])
         else:
-            source_code = br.open("http://www.spoj.pl/files/src/save/" + \
+            source_code = br.open("https://www.spoj.com/files/src/save/" + \
                                                                        entry[1])
             header = dict(source_code.info())
             filename = ""


### PR DESCRIPTION
This beautiful script was unable to fetch the solutions due to some minor format changes at SPOJ's end. Please merge this and make it open for use again.

Error lines: 
- Reached EOF, siglist format has probably changed, contact author
- ssl.CertificateError: hostname 'www.spoj.pl' doesn't match either of '*.spoj.com', 'spoj.com'

Changes done in the diff
- Protocol security changed from http to https
- spoj.pl to spoj.com

Test Plan : Downloaded my solutions from SPOJ after the changes and it succeeded gracefully.

Screenshot for reference
<img width="360" alt="screen shot 2019-01-08 at 4 59 44 am" src="https://user-images.githubusercontent.com/6589094/50799665-f6069680-1302-11e9-9f94-53217d7f4371.png">
